### PR TITLE
Parse reflector data

### DIFF
--- a/include/s3000_laser/sicks3000.h
+++ b/include/s3000_laser/sicks3000.h
@@ -49,7 +49,7 @@ class SickS3000
   public:
 
     // Constructor
-    SickS3000( std::string port );
+    SickS3000( std::string port, int baudRate );
 
     // Destructor
     ~SickS3000();

--- a/include/s3000_laser/sicks3000.h
+++ b/include/s3000_laser/sicks3000.h
@@ -43,6 +43,11 @@
 #define S3000_DEFAULT_PARITY	   "none"
 #define S3000_DEFAULT_DATA_SIZE    8
 
+//! Converts degrees to radians
+inline double DTOR(double val){
+    return val*3.141592653589793/180.0;
+}
+
 // The laser device class.
 class SickS3000
 {

--- a/src/s3000_laser.cc
+++ b/src/s3000_laser.cc
@@ -98,7 +98,7 @@ public:
 		private_node_handle_.param("topic_name", topic_name, string("/scan"));
 		private_node_handle_.param<bool> ("publish_tf", publish_tf_, false);
 		private_node_handle_.param<bool> ("publish_scan", publish_scan_, true);
-		laser_data_pub_ = laser_node_handle.advertise<sensor_msgs::LaserScan>(topic_name, 100);
+		laser_data_pub_ = laser_node_handle.advertise<sensor_msgs::LaserScan>(topic_name, 1);
 		running = false;
 		private_node_handle_.param("frame_id", frame_id_, string("/laser"));
 		

--- a/src/s3000_laser.cc
+++ b/src/s3000_laser.cc
@@ -47,6 +47,7 @@ private:
 	sensor_msgs::LaserScan reading;
 
 	string port;
+	int baud_rate;
 
 	self_test::TestRunner self_test_;
 	diagnostic_updater::Updater diagnostic_;
@@ -69,7 +70,7 @@ private:
 	std::string error_status_;
 	//! Name of the frame associated
 	string frame_id_;
-
+	string topic_name;
 	double desired_freq_;
 	diagnostic_updater::FrequencyStatus freq_diag_;
 	//! Enables/disables the scan publication
@@ -86,10 +87,11 @@ public:
 	{
 		ros::NodeHandle laser_node_handle(node_handle_, "s3000_laser");
 		private_node_handle_.param("port", port, string("/dev/ttyUSB1"));
-
+		private_node_handle_.param("baud_rate", baud_rate, 500000);
+		private_node_handle_.param("topic_name", topic_name, string("/scan"));
 		private_node_handle_.param<bool> ("publish_tf", publish_tf_, false);
 		private_node_handle_.param<bool> ("publish_scan", publish_scan_, true);
-		laser_data_pub_ = laser_node_handle.advertise<sensor_msgs::LaserScan>("/scan", 100);
+		laser_data_pub_ = laser_node_handle.advertise<sensor_msgs::LaserScan>(topic_name, 100);
 		running = false;
 		private_node_handle_.param("frame_id", frame_id_, string("/laser"));
 		reading.header.frame_id = frame_id_;
@@ -99,12 +101,13 @@ public:
 		diagnostic_.add( freq_diag_ );
 		diagnostic_.add( "Laser S3000 Status", this, &s3000node::deviceStatus );
 		ROS_INFO("s3000node: Port = %s", port.c_str());
+		ROS_INFO("s3000node: Baudrate = %d", baud_rate);
 		
 		// Advertises new service to enable/disable the scan publication
 		enable_disable_srv_ = private_node_handle_.advertiseService("enable_disable",  &s3000node::EnableDisable, this);
 		
 		// Create SickS3000 in the given port
-		laser = new SickS3000( port );
+		laser = new SickS3000( port, baud_rate );
 	}
 
 	~s3000node()

--- a/src/s3000_laser.cc
+++ b/src/s3000_laser.cc
@@ -85,15 +85,26 @@ public:
 	desired_freq_(20), 
 	freq_diag_(diagnostic_updater::FrequencyStatusParam(&desired_freq_, &desired_freq_, 0.05))
 	{
+	    float angle_min_deg, angle_max_deg, angle_increment_deg;
+	    
 		ros::NodeHandle laser_node_handle(node_handle_, "s3000_laser");
 		private_node_handle_.param("port", port, string("/dev/ttyUSB1"));
 		private_node_handle_.param("baud_rate", baud_rate, 500000);
+		private_node_handle_.param<float>("range_min", reading.range_min, 0 );
+		private_node_handle_.param<float>("range_max", reading.range_max, 40 );
+		private_node_handle_.param<float>("angle_min", angle_min_deg, -100 );
+		private_node_handle_.param<float>("angle_max", angle_max_deg, 100 );
+		private_node_handle_.param<float>("angle_increment", angle_increment_deg, 0.25 );
 		private_node_handle_.param("topic_name", topic_name, string("/scan"));
 		private_node_handle_.param<bool> ("publish_tf", publish_tf_, false);
 		private_node_handle_.param<bool> ("publish_scan", publish_scan_, true);
 		laser_data_pub_ = laser_node_handle.advertise<sensor_msgs::LaserScan>(topic_name, 100);
 		running = false;
 		private_node_handle_.param("frame_id", frame_id_, string("/laser"));
+		
+		reading.angle_min = DTOR(angle_min_deg);
+		reading.angle_max = DTOR(angle_max_deg);
+		reading.angle_increment = DTOR(angle_increment_deg);
 		reading.header.frame_id = frame_id_;
 			
 		self_test_.add("Connect Test", this, &s3000node::ConnectTest);

--- a/src/sicks3000.cc
+++ b/src/sicks3000.cc
@@ -48,7 +48,7 @@ double DTOR(double val){
 /*!	\fn SickS3000::SickS3000()
  * 	\brief Public constructor
 */
-SickS3000::SickS3000( std::string port )
+SickS3000::SickS3000( std::string port, int baudRate )
 {
   rx_count = 0;
   // allocate our recieve buffer
@@ -60,7 +60,7 @@ SickS3000::SickS3000( std::string port )
   mirror = 0;  // TODO move to property
 
   // Create serial port
-  serial= new SerialDevice(port.c_str(), S3000_DEFAULT_TRANSFERRATE, S3000_DEFAULT_PARITY, S3000_DEFAULT_DATA_SIZE); //Creates serial device
+  serial= new SerialDevice(port.c_str(), baudRate, S3000_DEFAULT_PARITY, S3000_DEFAULT_DATA_SIZE); //Creates serial device
 
   return;
 }
@@ -121,6 +121,22 @@ void SickS3000::SetScannerParams(sensor_msgs::LaserScan& scan, int data_count)
 
 		recognisedScanner = true;
 	}
+
+
+    if (data_count == 381) // sicks3000 0.5deg resolution
+    {
+        scan.angle_min  = static_cast<float> (DTOR(-95));
+        scan.angle_max  = static_cast<float> (DTOR(95));
+        scan.angle_increment =  static_cast<float> (DTOR(0.5));
+        scan.time_increment = (1.0/20.0) / 381.0; // Freq 20Hz
+        scan.scan_time = (1.0/20.0);
+        scan.range_min  =  0;
+        scan.range_max  =  49;   // check ?
+
+        recognisedScanner = true;
+    }
+
+
 
   if (data_count == 541) // sicks30b
   {

--- a/src/sicks3000.cc
+++ b/src/sicks3000.cc
@@ -286,7 +286,8 @@ int SickS3000::ProcessLaserData(sensor_msgs::LaserScan& scan, bool& bValidData)
             uint32_t reflector_data, num_ranges = ( scan.angle_max - scan.angle_min ) / scan.angle_increment;
     
             scan.header.stamp = ros::Time::now();
-            scan.ranges.resize( num_ranges, scan.range_min-1 );
+            scan.ranges.resize( num_ranges );
+            std::fill( scan.ranges.begin(), scan.ranges.end(), scan.range_min-1 );
             scan.intensities.clear();  // not used
             
             for ( size_t i=0; i< reflector_count; ++i )


### PR DESCRIPTION
- implemented parsing of reflector data ('CCCC' headers)
- allow user to specify laser settings (range, angles, etc.) from launch files via ROS params
